### PR TITLE
Improve accessibility, fix deprecation, and remove dead code

### DIFF
--- a/mytime/src/main/java/com/harringa/mytime/MyTimeMainActivity.java
+++ b/mytime/src/main/java/com/harringa/mytime/MyTimeMainActivity.java
@@ -1,17 +1,17 @@
 package com.harringa.mytime;
 
 import android.app.Activity;
-import android.app.Fragment;
+
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
-import android.view.LayoutInflater;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
+
 import android.widget.Button;
 import android.widget.ListView;
 import android.widget.TimePicker;
@@ -77,13 +77,8 @@ public class MyTimeMainActivity extends Activity implements View.OnClickListener
         updateCheckInList();
         TimePicker timePicker = (TimePicker) this.findViewById(R.id.timePicker);
         LocalDateTime now = LocalDateTime.now();
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-            timePicker.setHour(now.getHour());
-            timePicker.setMinute(now.getMinute());
-        } else {
-            timePicker.setCurrentHour(now.getHour());
-            timePicker.setCurrentMinute(now.getMinute());
-        }
+        timePicker.setHour(now.getHour());
+        timePicker.setMinute(now.getMinute());
     }
 
     @Override
@@ -94,14 +89,8 @@ public class MyTimeMainActivity extends Activity implements View.OnClickListener
         v.setEnabled(false);
 
         TimePicker timePicker = (TimePicker) this.findViewById(R.id.timePicker);
-        int hour, minute;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-            hour = timePicker.getHour();
-            minute = timePicker.getMinute();
-        } else {
-            hour = timePicker.getCurrentHour();
-            minute = timePicker.getCurrentMinute();
-        }
+        int hour = timePicker.getHour();
+        int minute = timePicker.getMinute();
         final LocalDateTime newTime = LocalDateTime.now()
                 .withHour(hour)
                 .withMinute(minute)
@@ -190,21 +179,6 @@ public class MyTimeMainActivity extends Activity implements View.OnClickListener
 
         if (checkInContentProvider != null) {
             checkInContentProvider.close();
-        }
-    }
-
-    /**
-     * A placeholder fragment containing a simple view.
-     */
-    public static class PlaceholderFragment extends Fragment {
-
-        public PlaceholderFragment() {
-        }
-
-        @Override
-        public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                Bundle savedInstanceState) {
-            return inflater.inflate(R.layout.fragment_main, container, false);
         }
     }
 

--- a/mytime/src/main/java/com/harringa/mytime/view/CheckInAdapter.java
+++ b/mytime/src/main/java/com/harringa/mytime/view/CheckInAdapter.java
@@ -108,7 +108,7 @@ public class CheckInAdapter extends BaseAdapter {
             final java.time.Duration totalTime = TimeCalculator.totalTime(sortedDateTimes);
             final long totalHours = totalTime.toHours();
             if (totalHours >= 8) {
-                holder.dateTotal.setTextColor(context.getResources().getColor(R.color.forest_green));
+                holder.dateTotal.setTextColor(androidx.core.content.ContextCompat.getColor(context, R.color.forest_green));
             } else {
                 holder.dateTotal.setTextColor(Color.RED);
             }

--- a/mytime/src/main/res/layout/activity_main.xml
+++ b/mytime/src/main/res/layout/activity_main.xml
@@ -10,7 +10,8 @@
             android:layout_width="match_parent"
             android:layout_height="0dip"
             android:layout_weight="1"
-            android:id="@+id/checkInListView"/>
+            android:id="@+id/checkInListView"
+            android:contentDescription="@string/checkInListDescription"/>
 
     <FrameLayout
             android:layout_width="match_parent"
@@ -19,12 +20,14 @@
         <TimePicker
                 android:layout_width="wrap_content"
                 android:layout_height="120dp"
-                android:id="@+id/timePicker"/>
+                android:id="@+id/timePicker"
+                android:contentDescription="@string/timePickerDescription"/>
         <Button
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/checkInButton"
                 android:id="@+id/checkIn"
+                android:contentDescription="@string/checkInButtonDescription"
                 android:layout_gravity="center|end"
                 android:layout_marginRight="@dimen/activity_horizontal_margin"
                 android:layout_marginEnd="@dimen/activity_horizontal_margin"

--- a/mytime/src/main/res/layout/check_in_list.xml
+++ b/mytime/src/main/res/layout/check_in_list.xml
@@ -22,6 +22,7 @@
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:text="@string/checkInDateHeadingText"
                 android:id="@+id/checkInDate"
+                android:contentDescription="@string/checkInDateDescription"
                 android:layout_weight="1"/>
 
         <TextView
@@ -31,6 +32,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/dateTotalHeading"
                 android:id="@+id/dateTotal"
+                android:contentDescription="@string/dateTotalDescription"
                 android:layout_weight="1"/>
     </LinearLayout>
 
@@ -41,6 +43,7 @@
             android:layout_height="wrap_content"
             android:layout_marginRight="10dp"
             android:layout_marginEnd="10dp"
-            android:text="@string/defaultCheckInTimeText"/>
+            android:text="@string/defaultCheckInTimeText"
+            android:contentDescription="@string/checkInTimesDescription"/>
 
 </LinearLayout>

--- a/mytime/src/main/res/layout/fragment_main.xml
+++ b/mytime/src/main/res/layout/fragment_main.xml
@@ -1,8 +1,0 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.harringa.mytime.MyTimeMainActivity$PlaceholderFragment">
-
-
-</RelativeLayout>

--- a/mytime/src/main/res/values/strings.xml
+++ b/mytime/src/main/res/values/strings.xml
@@ -2,12 +2,18 @@
 <resources>
 
     <string name="app_name">My Time</string>
-    <string name="hello_world">Hello world!</string>
+
     <string name="action_settings">Settings</string>
     <string name="checkInButton">Check In</string>
     <string name="defaultCheckInTimeText">checkInTimes</string>
     <string name="checkInDateHeadingText">checkInDateHeading</string>
     <string name="dateTotalHeading">dateTotalHeading</string>
     <string name="missingCheckInText">Missing Check In</string>
+    <string name="checkInListDescription">List of check-in times grouped by date</string>
+    <string name="timePickerDescription">Select check-in time</string>
+    <string name="checkInButtonDescription">Save check-in at selected time</string>
+    <string name="checkInDateDescription">Check-in date</string>
+    <string name="dateTotalDescription">Total hours worked</string>
+    <string name="checkInTimesDescription">Check-in times for this date</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- Add `contentDescription` attributes to all UI elements for TalkBack screen reader support (addresses #15, #16)
- Replace deprecated `getResources().getColor()` with `ContextCompat.getColor()` in CheckInAdapter
- Remove unused `PlaceholderFragment` class, `fragment_main.xml` layout, and `hello_world` string resource
- Remove dead pre-M (API 23) version check branches since minSdk is 26

## Test plan
- [ ] Verify app builds and launches without errors
- [ ] Confirm TalkBack reads content descriptions for TimePicker, Check In button, and list items
- [ ] Verify check-in flow still works end-to-end
- [ ] Confirm color coding (green >= 8h, red < 8h) still displays correctly

https://claude.ai/code/session_011vrN8BTH2sB3qK8Qt3b87w