### PR TITLE
Handle Android 15 edge-to-edge and predictive back changes

### DIFF
--- a/mytime/src/main/AndroidManifest.xml
+++ b/mytime/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AppTheme"
+        android:enableOnBackInvokedCallback="true" >
         <activity
             android:name=".MyTimeMainActivity" android:exported="true">
             <intent-filter>

--- a/mytime/src/main/res/layout/activity_main.xml
+++ b/mytime/src/main/res/layout/activity_main.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     tools:context="com.harringa.mytime.MyTimeMainActivity">
 
     <ListView


### PR DESCRIPTION
Android 15 (API 35) enforces edge-to-edge display, which causes app
content to draw behind system bars. Add fitsSystemWindows to the root
layout to ensure proper insets handling. Also opt-in to the predictive
back gesture via enableOnBackInvokedCallback in the manifest.

https://claude.ai/code/session_01FMfYpdK5u8kdPxmrpM99rD